### PR TITLE
weekly/4/issue#50 랭킹 조회 기능 구현

### DIFF
--- a/src/main/java/supernova/whokie/group/Groups.java
+++ b/src/main/java/supernova/whokie/group/Groups.java
@@ -2,16 +2,14 @@ package supernova.whokie.group;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import supernova.whokie.global.entity.BaseTimeEntity;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@Getter
 public class Groups extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/supernova/whokie/group/repository/GroupsRepository.java
+++ b/src/main/java/supernova/whokie/group/repository/GroupsRepository.java
@@ -1,0 +1,7 @@
+package supernova.whokie.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import supernova.whokie.group.Groups;
+
+public interface GroupsRepository extends JpaRepository<Groups, Long> {
+}

--- a/src/main/java/supernova/whokie/ranking/Ranking.java
+++ b/src/main/java/supernova/whokie/ranking/Ranking.java
@@ -1,31 +1,30 @@
 package supernova.whokie.ranking;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import supernova.whokie.group.Groups;
 import supernova.whokie.user.Users;
 
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Getter
 public class Ranking {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long questionId;
+    private String question;
 
     private Integer count;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private Users users;
 
-    private Long groupId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Groups groups;
 }

--- a/src/main/java/supernova/whokie/ranking/controller/RankingController.java
+++ b/src/main/java/supernova/whokie/ranking/controller/RankingController.java
@@ -1,26 +1,34 @@
 package supernova.whokie.ranking.controller;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import supernova.whokie.global.annotation.Authenticate;
 import supernova.whokie.ranking.controller.dto.RankingResponse;
-
-import java.util.List;
+import supernova.whokie.ranking.service.RankingService;
 
 @RestController
-@RequestMapping("/api/profile/ranking")
+@RequestMapping("/api/ranking")
+@AllArgsConstructor
 public class RankingController {
+    private final RankingService rankingService;
 
     @GetMapping("/{user-Id}")
     public RankingResponse.Ranks getProfileRanking(
-            @PathVariable("user-Id") String userId
+            @NotNull @Min(1) @PathVariable("user-Id") Long userId
     ) {
-        return RankingResponse.Ranks.builder()
-                .ranks(List.of(new RankingResponse.Rank(1L, 12L, "quest1", 1, 123, "GLOBAL"),
-                        new RankingResponse.Rank(2L, 13L, "quest2", 2, 12, "group1"),
-                        new RankingResponse.Rank(3L, 14L, "quest3", 3, 1, "group1")))
-                .build();
+        return RankingResponse.Ranks.from(rankingService.getUserRanking(userId));
+    }
+
+    @GetMapping("")
+    public RankingResponse.Ranks getMyProfileRanking(
+            @Authenticate Long userId
+    ) {
+        return RankingResponse.Ranks.from(rankingService.getUserRanking(userId));
     }
 
 }

--- a/src/main/java/supernova/whokie/ranking/controller/dto/RankingResponse.java
+++ b/src/main/java/supernova/whokie/ranking/controller/dto/RankingResponse.java
@@ -1,6 +1,7 @@
 package supernova.whokie.ranking.controller.dto;
 
 import lombok.Builder;
+import supernova.whokie.ranking.service.dto.RankingModel;
 
 import java.util.List;
 
@@ -10,17 +11,29 @@ public class RankingResponse {
     public record Ranks(
             List<Rank> ranks
     ) {
+        public static RankingResponse.Ranks from(List<RankingModel.Rank> models) {
+            return Ranks.builder()
+                    .ranks(models.stream().map(RankingResponse.Rank::from).toList())
+                    .build();
+        }
     }
 
     @Builder
     public record Rank(
             Long rankingId,
-            Long questionId,
             String question,
             int rank,
             int count,
             String groupName
     ) {
-
+        public static RankingResponse.Rank from(RankingModel.Rank model) {
+            return RankingResponse.Rank.builder()
+                    .rankingId(model.rankingId())
+                    .question(model.question())
+                    .rank(model.rank())
+                    .count(model.count())
+                    .groupName(model.groupName())
+                    .build();
+        }
     }
 }

--- a/src/main/java/supernova/whokie/ranking/infrastructure/repoistory/RankingRepository.java
+++ b/src/main/java/supernova/whokie/ranking/infrastructure/repoistory/RankingRepository.java
@@ -1,0 +1,10 @@
+package supernova.whokie.ranking.infrastructure.repoistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import supernova.whokie.ranking.Ranking;
+
+import java.util.List;
+
+public interface RankingRepository extends JpaRepository<Ranking, Long> {
+    List<Ranking> findTop3ByUsers_IdOrderByCountDesc(Long userId);
+}

--- a/src/main/java/supernova/whokie/ranking/service/RankingService.java
+++ b/src/main/java/supernova/whokie/ranking/service/RankingService.java
@@ -1,0 +1,23 @@
+package supernova.whokie.ranking.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import supernova.whokie.ranking.Ranking;
+import supernova.whokie.ranking.infrastructure.repoistory.RankingRepository;
+import supernova.whokie.ranking.service.dto.RankingModel;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@AllArgsConstructor
+public class RankingService {
+    private final RankingRepository rankingRepository;
+
+    public List<RankingModel.Rank> getUserRanking(Long userId) {
+        List<Ranking> entities = rankingRepository.findTop3ByUsers_IdOrderByCountDesc(userId);
+        return IntStream.range(0, entities.size())
+                .mapToObj(i -> RankingModel.Rank.from(entities.get(i), i + 1))
+                .toList();
+    }
+}

--- a/src/main/java/supernova/whokie/ranking/service/dto/RankingModel.java
+++ b/src/main/java/supernova/whokie/ranking/service/dto/RankingModel.java
@@ -1,0 +1,26 @@
+package supernova.whokie.ranking.service.dto;
+
+import lombok.Builder;
+import supernova.whokie.ranking.Ranking;
+
+public class RankingModel {
+
+    @Builder
+    public record Rank(
+            Long rankingId,
+            String question,
+            int rank,
+            int count,
+            String groupName
+    ) {
+        public static RankingModel.Rank from(Ranking entity, int rank) {
+            return RankingModel.Rank.builder()
+                    .rankingId(entity.getId())
+                    .question(entity.getQuestion())
+                    .rank(rank)
+                    .count(entity.getCount())
+                    .groupName(entity.getGroups().getGroupName())
+                    .build();
+        }
+    }
+}

--- a/src/test/java/supernova/whokie/ranking/infrastructure/repoistory/RankingRepositoryTest.java
+++ b/src/test/java/supernova/whokie/ranking/infrastructure/repoistory/RankingRepositoryTest.java
@@ -1,0 +1,57 @@
+package supernova.whokie.ranking.infrastructure.repoistory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import supernova.whokie.group.Groups;
+import supernova.whokie.group.repository.GroupsRepository;
+import supernova.whokie.ranking.Ranking;
+import supernova.whokie.user.Users;
+import supernova.whokie.user.repository.UsersRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class RankingRepositoryTest {
+    @Autowired
+    private RankingRepository rankingRepository;
+    @Autowired
+    private UsersRepository usersRepository;
+    @Autowired
+    private GroupsRepository groupsRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("userId로 랭킹 조회")
+    void findByUsers_IdOrderByCountDesc() {
+        // given
+        Users user = Users.builder().id(1L).build();
+        usersRepository.save(user);
+        Groups group = Groups.builder().id(1L).groupName("group").build();
+        groupsRepository.save(group);
+        Ranking ranking1 = Ranking.builder().id(1L).users(user).count(100).groups(group).build();
+        Ranking ranking2 = Ranking.builder().id(2L).users(user).count(70).groups(group).build();
+        Ranking ranking3 = Ranking.builder().id(3L).users(user).count(90).groups(group).build();
+        Ranking ranking4 = Ranking.builder().id(4L).users(user).count(80).groups(group).build();
+        rankingRepository.saveAll(List.of(ranking1, ranking2, ranking3, ranking4));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<Ranking> actual = rankingRepository.findTop3ByUsers_IdOrderByCountDesc(user.getId());
+
+        // then
+        assertThat(actual).hasSize(3);
+        assertThat(actual.get(0).getCount()).isEqualTo(ranking1.getCount());
+        assertThat(actual.get(1).getCount()).isEqualTo(ranking3.getCount());
+        assertThat(actual.get(2).getCount()).isEqualTo(ranking4.getCount());
+    }
+}

--- a/src/test/java/supernova/whokie/ranking/service/RankingServiceTest.java
+++ b/src/test/java/supernova/whokie/ranking/service/RankingServiceTest.java
@@ -1,0 +1,53 @@
+package supernova.whokie.ranking.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import supernova.whokie.group.Groups;
+import supernova.whokie.ranking.Ranking;
+import supernova.whokie.ranking.infrastructure.repoistory.RankingRepository;
+import supernova.whokie.ranking.service.dto.RankingModel;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class RankingServiceTest {
+    @Autowired
+    private RankingService rankingService;
+    @MockBean
+    private RankingRepository rankingRepository;
+
+    @Test
+    @DisplayName("특정 유저 랭킹 조회")
+    void getUserRankingTest() {
+        // given
+        Groups group = Groups.builder().build();
+        Ranking ranking1 = Ranking.builder().count(100).groups(group).build();
+        Ranking ranking2 = Ranking.builder().count(90).groups(group).build();
+        Ranking ranking3 = Ranking.builder().count(80).groups(group).build();
+        List<Ranking> entities = List.of(ranking1, ranking2, ranking3);
+        given(rankingRepository.findTop3ByUsers_IdOrderByCountDesc(any()))
+                .willReturn(entities);
+
+        // when
+        List<RankingModel.Rank> actual = rankingService.getUserRanking(1L);
+
+        // then
+        assertThat(actual).hasSize(3);
+        assertThat(actual.get(0).count()).isEqualTo(ranking1.getCount());
+        assertThat(actual.get(1).count()).isEqualTo(ranking2.getCount());
+        assertThat(actual.get(2).count()).isEqualTo(ranking3.getCount());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* groups와 다대일 관계 설정함
* 테이블의 questionId 필드 삭제
* api response 변경
* 랭킹 조회 기능 구현

## 이미지 첨부

<!--- 
관련 이미지가 있다면 첨부해주세요.
복잡한 도메인로직이 있다면 플로우차트로 표현해주세요.
--->

## To Reviewers 📢
* groups와 다대일 관계 설정함
* 테이블의 questionId 필드 삭제
* api response의 questionId 필드 삭제

## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [x] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #50
